### PR TITLE
Master python3 with affine

### DIFF
--- a/README
+++ b/README
@@ -41,3 +41,17 @@ python setup.py install
 TODO:
 - Write MINC header
 - Read header only
+
+TO INSTALL ON ANOTHER ENVIRONMENT:
+step 1:
+    conda env create -f environment.yml
+
+step 2:
+    conda activate pyezminc
+    python setup.py install --mincdir /path/to/minc/enivornment/
+    python setup.py sdist bdist_wheel --mincdir /path/to/minc/enivornment/
+
+step 3:
+    conda deactivate
+    conda activate YOUR-ENV-NAME
+    pip install /path/to/your/package/dist/your_package_name-version-***.whl

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,32 @@
+name: pyezminc
+channels:
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1
+  - _openmp_mutex=5.1
+  - bzip2=1.0.8
+  - ca-certificates=2024.3.11
+  - ld_impl_linux-64=2.38
+  - libffi=3.4.4
+  - libgcc-ng=11.2.0
+  - libgomp=11.2.0
+  - libstdcxx-ng=11.2.0
+  - libuuid=1.41.5
+  - ncurses=6.4
+  - openssl=3.0.14
+  - pip=24.0
+  - python=3.11.9
+  - readline=8.2
+  - setuptools=69.5.1
+  - sqlite=3.45.3
+  - tk=8.6.14
+  - tzdata=2024a
+  - wheel=0.43.0
+  - xz=5.4.6
+  - zlib=1.2.13
+  - pip:
+      - cython==3.0.10
+      - numpy==2.0.0
+      - pyezminc==1.2
+      - scipy==1.14.0
+prefix: /scratch/03/ahrasoulian/other/miniconda3/envs/pyezminc

--- a/minc/image.py
+++ b/minc/image.py
@@ -276,6 +276,23 @@ class Image(object):
             world.append(sum(p*q for p,q in zip(world_tmp, cosines_transpose[i]))) 
         return world
 
+    def get_affine_xyz(self):
+        dimensions = ('xspace', 'yspace', 'zspace')
+        _dir_cos = self._get_direction_cosines()
+        cosines = tuple(_dir_cos[d] for d in dimensions)
+        cosines_transpose = np.transpose(np.asarray(cosines))
+
+        affine_matrix = np.array([
+            [self.spacing()[0] * cosines_transpose[0, 0], self.spacing()[1] * cosines_transpose[0, 1],
+             self.spacing()[2] * cosines_transpose[0, 2], sum(s * c for s, c in zip(self.start(), cosines_transpose[0]))],
+            [self.spacing()[0] * cosines_transpose[1, 0], self.spacing()[1] * cosines_transpose[1, 1],
+             self.spacing()[2] * cosines_transpose[1, 2], sum(s * c for s, c in zip(self.start(), cosines_transpose[1]))],
+            [self.spacing()[0] * cosines_transpose[2, 0], self.spacing()[1] * cosines_transpose[2, 1],
+             self.spacing()[2] * cosines_transpose[2, 2], sum(s * c for s, c in zip(self.start(), cosines_transpose[2]))],
+            [0, 0, 0, 1]
+        ])
+        return affine_matrix
+
     def scanner_manufacturer(self, normalize=True):
         extract = mincinfo(self.header, 'study:manufacturer')
         if not normalize:

--- a/minc/mask.py
+++ b/minc/mask.py
@@ -30,10 +30,10 @@ class Mask(Image):
             self.data = self._minc_to_numpy(self.data)
     
     def _minc_to_numpy(self, data):
-        return np.logical_not(data.astype(np.bool)).astype(np.dtype)
+        return np.logical_not(data.astype(bool)).astype(data.dtype)
     
     def _numpy_to_minc(self, data):
-        return np.logical_not(data.astype(np.bool)).astype(self.dtype)
+        return np.logical_not(data.astype(bool)).astype(self.dtype)
         
     def _load(self, name, *args, **kwargs):
         '''Load a file'''

--- a/minc/pyezminc.pyx
+++ b/minc/pyezminc.pyx
@@ -307,7 +307,7 @@ cdef class EZMincWrapper(object):
                     raise Exception('attribute type not recognized:{} {} {}'.format(varname, attrname, attrtype))
 
                 if debug:
-                    print "{0}:{1} = '{2}' ({3})".format(varname,attrname,attrvalue,attrtype)
+                    print("{0}:{1} = '{2}' ({3})".format(varname,attrname,attrvalue,attrtype))
                 header[varname][attrname] = attrvalue
                 pass
 
@@ -569,7 +569,7 @@ cdef class parallel_input_iterator:
 #        self._it.value(ret)
 #        return ret
 
-    def open(self,vector[string] output,string mask=""):
+    def open(self,vector[string] output,string mask="".encode('utf8')):
         self._it.open(output,mask)
 
 


### PR DESCRIPTION
The setup file and a few numpy functions were incompatible with Python 3, that are fixed now.
A new method is added to the Image class to return 4x4 affine matrix.
Instructions are added at the end of README for installing this package on another Conda Environment.